### PR TITLE
fix page reload on locale change

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -86,8 +86,8 @@ export default function Home() {
         </Box>
       </Container>
 
-      <Container id="skills" maxWidth={false} sx={{width: '100vw', height: '100vh', textAlign: 'center', background: containerGradient.bottomToTop }}>
-        <Box sx={{pt: 8}}>
+      <Container id="skills" maxWidth={false} sx={{width: '100vw', textAlign: 'center', background: containerGradient.bottomToTop }}>
+        <Box sx={{pt: 1}}>
           <Typography variant="h3" color="text.secondary">
             {t('whatIWorkWith')}
           </Typography>

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -21,9 +21,9 @@ export default function LanguageSwitcher() {
   }, [locale]);
 
   const switchLocale = (newLocale: string) => {
-    if (locale === newLocale) return; // Don't switch if it's the same locale
+    if (locale === newLocale) return; // Skip if it's the same locale
     
-    // Save current scroll position - try multiple methods
+    // Save current scroll position
     const scrollY = window.scrollY 
     
     sessionStorage.setItem('scrollPosition', scrollY.toString());
@@ -35,16 +35,7 @@ export default function LanguageSwitcher() {
   };
 
   return (
-    <Box 
-      sx={{ 
-        position: 'fixed', 
-        top: 20, 
-        right: 20, 
-        zIndex: 1000,
-        display: 'flex',
-        gap: 1
-      }}
-    >
+    <Box sx={{ position: 'fixed', top: 20, right: 20, zIndex: 1000, display: 'flex', gap: 1}} >
       <Button
         variant={locale === 'en' ? 'contained' : 'outlined'}
         size="small"

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -3,17 +3,30 @@
 import { Button, Box } from '@mui/material';
 import { useRouter } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
-import { useTransition } from 'react';
+import { useTransition, useEffect } from 'react';
 
 export default function LanguageSwitcher() {
   const router = useRouter();
   const locale = useLocale();
   const [isPending, startTransition] = useTransition();
 
+  // Restore scroll position after locale change
+  useEffect(() => {
+    const savedScrollY = sessionStorage.getItem('scrollPosition');
+    if (savedScrollY) {
+      const scrollPosition = parseInt(savedScrollY, 10);
+      window.scrollTo(0, scrollPosition);
+      sessionStorage.removeItem('scrollPosition'); // Clear after restoring
+    }
+  }, [locale]);
+
   const switchLocale = (newLocale: string) => {
     if (locale === newLocale) return; // Don't switch if it's the same locale
     
-    console.log('Switching from', locale, 'to', newLocale);
+    // Save current scroll position - try multiple methods
+    const scrollY = window.scrollY 
+    
+    sessionStorage.setItem('scrollPosition', scrollY.toString());
     
     startTransition(() => {
       // Navigate directly to the new locale URL

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,5 +26,5 @@
     "apiTechnologies": "API Technologies",
     "databases": "Databases",
     "devOpsTools": "DevOps & Cloud",
-    "whatIWorkWith": "What I Work With"
+    "whatIWorkWith": "Technologies I Work With"
 }


### PR DESCRIPTION
- **Update: Working on english token**
- **Fix reload action moved the scroll to the top, not instead the scroll is saved and the user stays on wherever is looking at when switching locale**
